### PR TITLE
Change API version from v1 to 1.1

### DIFF
--- a/moves/_moves.py
+++ b/moves/_moves.py
@@ -14,7 +14,7 @@ class MovesAPINotModifed(Exception):
 
 class MovesClient(object):
     """OAuth client for the Moves API"""
-    api_url = "https://api.moves-app.com/api/v1"
+    api_url = "https://api.moves-app.com/api/1.1"
     app_auth_url = "moves://app/authorize"
     web_auth_uri = "https://api.moves-app.com/oauth/v1/authorize"
     token_url = "https://api.moves-app.com/oauth/v1/access_token"


### PR DESCRIPTION
According to the documentation, the base URL for API calls has changed. Instead of "v1" it is now "1.1".
